### PR TITLE
Add BUFR minimizer utility

### DIFF
--- a/tools/bufr_minimizer/README.md
+++ b/tools/bufr_minimizer/README.md
@@ -1,0 +1,18 @@
+# BUFR Minimizer
+
+This utility reduces the size of an existing BUFR file by limiting the number
+of subsets kept for each subset type.  It can be useful when generating small
+sample BUFR files for unit tests or debugging.
+
+## Usage
+
+```bash
+python bufr_minimizer.py INPUT_FILE OUTPUT_FILE [--max-subsets N]
+```
+
+- `INPUT_FILE` – path to the original BUFR file.
+- `OUTPUT_FILE` – location where the minimized BUFR file will be written.
+- `--max-subsets` – optional maximum number of subsets to keep for each subset
+  type.  Defaults to `1000` if not provided.
+
+The script requires the python interface of the `nceplibs-bufr` library.

--- a/tools/bufr_minimizer/README.md
+++ b/tools/bufr_minimizer/README.md
@@ -7,7 +7,7 @@ sample BUFR files for unit tests or debugging.
 ## Usage
 
 ```bash
-python bufr_minimizer.py INPUT_FILE OUTPUT_FILE [--max-subsets N]
+python tools/bufr_minimizer/bufr_minimizer.py INPUT_FILE OUTPUT_FILE [--max-subsets N]
 ```
 
 - `INPUT_FILE` – path to the original BUFR file.
@@ -17,3 +17,6 @@ python bufr_minimizer.py INPUT_FILE OUTPUT_FILE [--max-subsets N]
 
 The script relies on the `ncepbufr` Python interface provided by the
 `NCEPLIBS-bufr` project.
+
+Make sure this package is installed and available on your `PYTHONPATH` before
+running the script.

--- a/tools/bufr_minimizer/README.md
+++ b/tools/bufr_minimizer/README.md
@@ -15,4 +15,5 @@ python bufr_minimizer.py INPUT_FILE OUTPUT_FILE [--max-subsets N]
 - `--max-subsets` – optional maximum number of subsets to keep for each subset
   type.  Defaults to `1000` if not provided.
 
-The script requires the python interface of the `nceplibs-bufr` library.
+The script relies on the `ncepbufr` Python interface provided by the
+`NCEPLIBS-bufr` project.

--- a/tools/bufr_minimizer/bufr_minimizer.py
+++ b/tools/bufr_minimizer/bufr_minimizer.py
@@ -41,7 +41,14 @@ def minimize_bufr(in_path: str, out_path: str, max_subsets: int = 1000) -> None:
                     pass
                 continue
 
-            bufr_out.open_message(msg_type, bufr_in.msg_date, bufr_in.receipt_time)
+            if bufr_in.receipt_time and bufr_in.receipt_time > 0:
+                bufr_out.open_message(
+                    msg_type,
+                    bufr_in.msg_date,
+                    bufr_in.receipt_time,
+                )
+            else:
+                bufr_out.open_message(msg_type, bufr_in.msg_date)
 
             copied = 0
             while bufr_in.load_subset() == 0:

--- a/tools/bufr_minimizer/bufr_minimizer.py
+++ b/tools/bufr_minimizer/bufr_minimizer.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Minimize BUFR files by limiting subsets per subset type.
+
+This script reads an input BUFR file and writes a reduced BUFR file
+containing at most a configurable number of subsets for each subset
+message type. The script relies on the python interface of the
+``nceplibs-bufr`` library which provides ``BUFRFile`` and ``BUFRMessage``
+classes for manipulating BUFR data.
+"""
+
+import argparse
+from collections import defaultdict
+
+import nceplibs.bufr as bufr
+
+
+def minimize_bufr(in_path: str, out_path: str, max_subsets: int = 1000) -> None:
+    """Create a reduced BUFR file keeping only a limited number of subsets.
+
+    Parameters
+    ----------
+    in_path : str
+        Path to the input BUFR file.
+    out_path : str
+        Path where the minimized BUFR file will be written.
+    max_subsets : int, optional
+        Maximum number of subsets to retain for each subset type. ``1000`` by
+        default.
+    """
+
+    subset_counts = defaultdict(int)
+
+    with bufr.BUFRFile(in_path, "r") as infile, bufr.BUFRFile(out_path, "w") as outfile:
+        for msg in infile:
+            subset_name = msg.subset
+            count = subset_counts[subset_name]
+
+            if count >= max_subsets:
+                continue
+
+            allowed = max_subsets - count
+
+            if msg.n_subsets > allowed:
+                msg = msg.slice(stop=allowed)
+
+            outfile.write(msg)
+            subset_counts[subset_name] += msg.n_subsets
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Reduce the size of a BUFR file by limiting subsets")
+    parser.add_argument("input", help="Path to the input BUFR file")
+    parser.add_argument("output", help="Path to the minimized BUFR file")
+    parser.add_argument("--max-subsets", type=int, default=1000, help="Maximum number of subsets per subset type (default: 1000)")
+
+    args = parser.parse_args()
+
+    minimize_bufr(args.input, args.output, args.max_subsets)

--- a/tools/bufr_minimizer/bufr_minimizer.py
+++ b/tools/bufr_minimizer/bufr_minimizer.py
@@ -1,17 +1,15 @@
 #!/usr/bin/env python3
 """Minimize BUFR files by limiting subsets per subset type.
 
-This script reads an input BUFR file and writes a reduced BUFR file
-containing at most a configurable number of subsets for each subset
-message type. The script relies on the python interface of the
-``nceplibs-bufr`` library which provides ``BUFRFile`` and ``BUFRMessage``
-classes for manipulating BUFR data.
+This script reads an input BUFR file via the ``ncepbufr`` interface and
+writes a reduced BUFR file containing at most a configurable number of
+subsets for each message type found in the input.
 """
 
 import argparse
 from collections import defaultdict
 
-import nceplibs.bufr as bufr
+import ncepbufr
 
 
 def minimize_bufr(in_path: str, out_path: str, max_subsets: int = 1000) -> None:
@@ -30,21 +28,31 @@ def minimize_bufr(in_path: str, out_path: str, max_subsets: int = 1000) -> None:
 
     subset_counts = defaultdict(int)
 
-    with bufr.BUFRFile(in_path, "r") as infile, bufr.BUFRFile(out_path, "w") as outfile:
-        for msg in infile:
-            subset_name = msg.subset
-            count = subset_counts[subset_name]
+    bufr_in = ncepbufr.open(in_path)
+    bufr_out = ncepbufr.open(out_path, "w", table=bufr_in)
 
-            if count >= max_subsets:
+    try:
+        while bufr_in.advance() == 0:
+            msg_type = bufr_in.msg_type
+            remaining = max_subsets - subset_counts[msg_type]
+
+            if remaining <= 0:
+                while bufr_in.load_subset() == 0:
+                    pass
                 continue
 
-            allowed = max_subsets - count
+            bufr_out.open_message(msg_type, bufr_in.msg_date, bufr_in.receipt_time)
 
-            if msg.n_subsets > allowed:
-                msg = msg.slice(stop=allowed)
-
-            outfile.write(msg)
-            subset_counts[subset_name] += msg.n_subsets
+            copied = 0
+            while bufr_in.load_subset() == 0:
+                if copied < remaining:
+                    bufr_out.copy_subset(bufr_in)
+                    copied += 1
+            bufr_out.close_message()
+            subset_counts[msg_type] += copied
+    finally:
+        bufr_in.close()
+        bufr_out.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a script using nceplibs-bufr to trim subsets in BUFR files
- document usage of the new tool

## Testing
- `tools/build_scripts/spoc_py_lint.sh tools/bufr_minimizer .` *(fails: pycodestyle not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685da396a41c8325a8c473dd82a15bf0