### PR TITLE
Add category-based subset limit to BUFR minimizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 .DS_Store
 .idea
 .nc
+NCEPLIBS-bufr/

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -16,8 +16,8 @@ TEST_CASES = [
             'input': 'testdata/2025040100-gdas.t00z.satwnd.tm00.bufr_d',
             'output': 'testrun/bufr_satwnd_amv_ahi_{splits/satId}.nc'
         },
-        'cmp': 'testoutput/bufr_satwnd_amv_ahi_goes-16.nc',
-        'result': 'testrun/bufr_satwnd_amv_ahi_goes-16.nc'
+        'cmp': 'testoutput/bufr_satwnd_amv_ahi_h9.nc',
+        'result': 'testrun/bufr_satwnd_amv_ahi_h9.nc'
     },
     {
         'map': 'bufr_satwnd_amv_avhrr',
@@ -25,8 +25,8 @@ TEST_CASES = [
             'input': 'testdata/2025040100-gdas.t00z.satwnd.tm00.bufr_d',
             'output': 'testrun/bufr_satwnd_amv_avhrr_{splits/satId}.nc'
         },
-        'cmp': 'testoutput/bufr_satwnd_amv_avhrr_goes-16.nc',
-        'result': 'testrun/bufr_satwnd_amv_avhrr_goes-16.nc'
+        'cmp': 'testoutput/bufr_satwnd_amv_avhrr_n19.nc',
+        'result': 'testrun/bufr_satwnd_amv_avhrr_n19.nc'
     },
     {
         'map': 'bufr_satwnd_amv_leogeo',
@@ -34,8 +34,8 @@ TEST_CASES = [
             'input': 'testdata/2025040100-gdas.t00z.satwnd.tm00.bufr_d',
             'output': 'testrun/bufr_satwnd_amv_leogeo_{splits/satId}.nc'
         },
-        'cmp': 'testoutput/bufr_satwnd_amv_leogeo_goes-16.nc',
-        'result': 'testrun/bufr_satwnd_amv_leogeo_goes-16.nc'
+        'cmp': 'testoutput/bufr_satwnd_amv_leogeo_multi.nc',
+        'result': 'testrun/bufr_satwnd_amv_leogeo_multi.nc'
     },
     {
         'map': 'bufr_satwnd_amv_modis',
@@ -43,8 +43,8 @@ TEST_CASES = [
             'input': 'testdata/2025040100-gdas.t00z.satwnd.tm00.bufr_d',
             'output': 'testrun/bufr_satwnd_amv_modis_{splits/satId}.nc'
         },
-        'cmp': 'testoutput/bufr_satwnd_amv_modis_goes-16.nc',
-        'result': 'testrun/bufr_satwnd_amv_modis_goes-16.nc'
+        'cmp': 'testoutput/bufr_satwnd_amv_modis_terra.nc',
+        'result': 'testrun/bufr_satwnd_amv_modis_terra.nc'
     },
     {
         'map': 'bufr_satwnd_amv_seviri',
@@ -52,8 +52,8 @@ TEST_CASES = [
             'input': 'testdata/2025040100-gdas.t00z.satwnd.tm00.bufr_d',
             'output': 'testrun/bufr_satwnd_amv_seviri_{splits/satId}.nc'
         },
-        'cmp': 'testoutput/bufr_satwnd_amv_seviri_goes-16.nc',
-        'result': 'testrun/bufr_satwnd_amv_seviri_goes-16.nc'
+        'cmp': 'testoutput/bufr_satwnd_amv_seviri_m10.nc',
+        'result': 'testrun/bufr_satwnd_amv_seviri_m10.nc'
     },
 
 ]

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -55,5 +55,4 @@ TEST_CASES = [
         'cmp': 'testoutput/bufr_satwnd_amv_seviri_m10.nc',
         'result': 'testrun/bufr_satwnd_amv_seviri_m10.nc'
     },
-
 ]

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -40,15 +40,11 @@ def test_create_obs_file(cfg):
 def test_create_obs_group(cfg):
     pytest.importorskip('pyioda')
 
-    module = importlib.import_module(cfg['module'])
+    module = importlib.import_module(cfg['map'])
 
-    bufr_path = os.path.join(DATA_DIR, cfg['bufr_file'])
-    map_path = os.path.join(DATA_DIR, cfg['mapping_file'])
+    args = cfg['args']
+    args['env'] = {'comm_name': 'world'}
 
-    if not (os.path.exists(bufr_path) and os.path.exists(map_path)):
-        pytest.skip('Required test files are missing')
-
-    env = {'comm_name': 'world'}
-    obs = module.create_obs_group(bufr_path, map_path, cfg['cycle_time'], env)
+    obs = module.create_obs_group(**args)
 
     assert obs is not None

--- a/tools/bufr_minimizer/README.md
+++ b/tools/bufr_minimizer/README.md
@@ -7,13 +7,16 @@ sample BUFR files for unit tests or debugging.
 ## Usage
 
 ```bash
-python tools/bufr_minimizer/bufr_minimizer.py INPUT_FILE OUTPUT_FILE [--max-subsets N]
+python tools/bufr_minimizer/bufr_minimizer.py INPUT_FILE OUTPUT_FILE [--max-subsets N] [--category-mnemonic MNEM]
 ```
 
 - `INPUT_FILE` – path to the original BUFR file.
 - `OUTPUT_FILE` – location where the minimized BUFR file will be written.
 - `--max-subsets` – optional maximum number of subsets to keep for each subset
-  type.  Defaults to `1000` if not provided.
+  type or category. Defaults to `1000` if not provided.
+- `--category-mnemonic` – optional mnemonic used to further categorize subsets.
+  When set, the subset limit applies to each unique combination of message type
+  and mnemonic value.
 
 The script relies on the `ncepbufr` Python interface provided by the
 `NCEPLIBS-bufr` project.

--- a/tools/bufr_minimizer/bufr_minimizer.py
+++ b/tools/bufr_minimizer/bufr_minimizer.py
@@ -1,18 +1,26 @@
 #!/usr/bin/env python3
-"""Minimize BUFR files by limiting subsets per subset type.
+"""Minimize BUFR files by limiting subsets per subset type or category.
 
 This script reads an input BUFR file via the ``ncepbufr`` interface and
-writes a reduced BUFR file containing at most a configurable number of
-subsets for each message type found in the input.
+writes a reduced BUFR file.  By default it keeps only a configurable
+number of subsets for each message type found in the input.  When a
+``category_mnemonic`` is provided, the limit is applied separately to
+each unique value of that mnemonic.
 """
 
 import argparse
 from collections import defaultdict
+from typing import Any, Tuple
 
 import ncepbufr
 
 
-def minimize_bufr(in_path: str, out_path: str, max_subsets: int = 1000) -> None:
+def minimize_bufr(
+    in_path: str,
+    out_path: str,
+    max_subsets: int = 1000,
+    category_mnemonic: str = "",
+) -> None:
     """Create a reduced BUFR file keeping only a limited number of subsets.
 
     Parameters
@@ -22,11 +30,14 @@ def minimize_bufr(in_path: str, out_path: str, max_subsets: int = 1000) -> None:
     out_path : str
         Path where the minimized BUFR file will be written.
     max_subsets : int, optional
-        Maximum number of subsets to retain for each subset type. ``1000`` by
-        default.
+        Maximum number of subsets to retain for each subset type or category.
+        ``1000`` by default.
+    category_mnemonic : str, optional
+        BUFR mnemonic used to further categorize subsets. When set, the
+        ``max_subsets`` limit is applied to each unique pair of message type and
+        value of this mnemonic. An empty string disables this behaviour.
     """
-
-    subset_counts = defaultdict(int)
+    subset_counts: defaultdict[Any, int] = defaultdict(int)
 
     bufr_in = ncepbufr.open(in_path)
     bufr_out = ncepbufr.open(out_path, "w", table=bufr_in)
@@ -34,29 +45,41 @@ def minimize_bufr(in_path: str, out_path: str, max_subsets: int = 1000) -> None:
     try:
         while bufr_in.advance() == 0:
             msg_type = bufr_in.msg_type
-            remaining = max_subsets - subset_counts[msg_type]
+            message_open = False
 
-            if remaining <= 0:
-                while bufr_in.load_subset() == 0:
-                    pass
-                continue
-
-            if bufr_in.receipt_time and bufr_in.receipt_time > 0:
-                bufr_out.open_message(
-                    msg_type,
-                    bufr_in.msg_date,
-                    bufr_in.receipt_time,
-                )
-            else:
-                bufr_out.open_message(msg_type, bufr_in.msg_date)
-
-            copied = 0
             while bufr_in.load_subset() == 0:
-                if copied < remaining:
-                    bufr_out.copy_subset(bufr_in)
-                    copied += 1
-            bufr_out.close_message()
-            subset_counts[msg_type] += copied
+                if category_mnemonic:
+                    try:
+                        cat_val = bufr_in.read_subset(category_mnemonic).squeeze()
+                        if hasattr(cat_val, "filled"):
+                            cat_val = cat_val.filled("")
+                        if hasattr(cat_val, "flatten"):
+                            cat_val = cat_val.flatten()[0]
+                        key: Tuple[Any, Any] = (msg_type, str(cat_val))
+                    except Exception:
+                        key = (msg_type, "")
+                else:
+                    key = msg_type
+
+                if subset_counts[key] >= max_subsets:
+                    continue
+
+                if not message_open:
+                    if bufr_in.receipt_time and bufr_in.receipt_time > 0:
+                        bufr_out.open_message(
+                            msg_type,
+                            bufr_in.msg_date,
+                            bufr_in.receipt_time,
+                        )
+                    else:
+                        bufr_out.open_message(msg_type, bufr_in.msg_date)
+                    message_open = True
+
+                bufr_out.copy_subset(bufr_in)
+                subset_counts[key] += 1
+
+            if message_open:
+                bufr_out.close_message()
     finally:
         bufr_in.close()
         bufr_out.close()
@@ -66,8 +89,21 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Reduce the size of a BUFR file by limiting subsets")
     parser.add_argument("input", help="Path to the input BUFR file")
     parser.add_argument("output", help="Path to the minimized BUFR file")
-    parser.add_argument("--max-subsets", type=int, default=1000, help="Maximum number of subsets per subset type (default: 1000)")
+    parser.add_argument(
+        "--max-subsets",
+        type=int,
+        default=1000,
+        help="Maximum number of subsets per subset type or category (default: 1000)",
+    )
+    parser.add_argument(
+        "--category-mnemonic",
+        default="",
+        help=(
+            "Mnemonic used to categorize subsets. When set, the subset limit is "
+            "applied separately for each message type and mnemonic value."
+        ),
+    )
 
     args = parser.parse_args()
 
-    minimize_bufr(args.input, args.output, args.max_subsets)
+    minimize_bufr(args.input, args.output, args.max_subsets, args.category_mnemonic)


### PR DESCRIPTION
## Summary
- extend `minimize_bufr` to accept optional `category_mnemonic`
- apply subset limits per message type and category value
- update CLI and docs
- ignore local `NCEPLIBS-bufr` directory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ncepbufr')*

------
https://chatgpt.com/codex/tasks/task_e_685ed6e315f88325bb5e794a4891e2c8